### PR TITLE
Fix dotnet version in path

### DIFF
--- a/Content/Content.mgcb
+++ b/Content/Content.mgcb
@@ -10,8 +10,8 @@
 
 #-------------------------------- References --------------------------------#
 
-/reference:../XNAnimationPipeline/bin/Debug/net6.0/XNAnimation.dll
-/reference:../XNAnimationPipeline/bin/Debug/net6.0/XNAnimationPipeline.dll
+/reference:../XNAnimationPipeline/bin/Debug/net8.0/XNAnimation.dll
+/reference:../XNAnimationPipeline/bin/Debug/net8.0/XNAnimationPipeline.dll
 
 #---------------------------------- Content ---------------------------------#
 


### PR DESCRIPTION
Project is setup for the newest MG version 3.8.2 which runs on net8.0.
However the mgcb file has /net6.0/ in the reference paths.