### PR TITLE
Expose keyframe property

### DIFF
--- a/XNAnimation/Controllers/AnimationController.cs
+++ b/XNAnimation/Controllers/AnimationController.cs
@@ -48,11 +48,12 @@ namespace XNAnimation.Controllers
 
         private bool hasFinished;
         private bool isPlaying;
+		private int keyframeIndex;
 
-        #region Properties
+		#region Properties
 
-        /// <inheritdoc />
-        public AnimationClip AnimationClip
+		/// <inheritdoc />
+		public AnimationClip AnimationClip
         {
             get { return animationClip; }
         }
@@ -154,6 +155,11 @@ namespace XNAnimation.Controllers
         public bool CrossFading
         {
             get { return crossFadeEnabled; }
+        }
+
+        public int CurrentKeyFrame 
+        {
+            get { return keyframeIndex; }
         }
 
         #endregion
@@ -367,12 +373,12 @@ namespace XNAnimation.Controllers
                 orientationInterpolation == InterpolationMode.None &&
                     scaleInterpolation == InterpolationMode.None)
             {
-                int keyframeIndex = animationChannel.GetKeyframeIndexByTime(animationTime);
+                keyframeIndex = animationChannel.GetKeyframeIndexByTime(animationTime);
                 outPose = animationChannel[keyframeIndex].Pose;
             }
             else
             {
-                int keyframeIndex = animationChannel.GetKeyframeIndexByTime(animationTime);
+                keyframeIndex = animationChannel.GetKeyframeIndexByTime(animationTime);
                 int nextKeyframeIndex;
 
                 // If we are looping then the next frame may wrap around to 

--- a/XNAnimation/Controllers/AnimationController.cs
+++ b/XNAnimation/Controllers/AnimationController.cs
@@ -48,12 +48,12 @@ namespace XNAnimation.Controllers
 
         private bool hasFinished;
         private bool isPlaying;
-		private int keyframeIndex;
+	private int keyframeIndex;
 
-		#region Properties
+	#region Properties
 
-		/// <inheritdoc />
-		public AnimationClip AnimationClip
+	/// <inheritdoc />
+	public AnimationClip AnimationClip
         {
             get { return animationClip; }
         }


### PR DESCRIPTION
In my walking cycle I wanted to be able to play a footstep SFX which should align with specific keyframes in the animation.
Doing this based on time/duration calculations is uncomfy. I propose caching the currentkeyframe in a field, which is already being calculated, and exposing this with a get prop.

In my game ive been able to use this to play SFX on certain keyframe numbers without having to jumble around with timespans.
This is also useful to be able to know when an animation is restarting in a a looping sequence because then hasFinished isnt useful.