### PR TITLE
Feature/remove bone enumerator allocation

### DIFF
--- a/XNAnimation/SkinnedModelBone.cs
+++ b/XNAnimation/SkinnedModelBone.cs
@@ -105,11 +105,11 @@ namespace XNAnimation
         private void CopyBindPoseTo(Pose[] destination, ref int boneIndex)
         {
             destination[boneIndex++] = bindPose;
-			for (int i = 0; i < children.Count; i++)
-			{
-				children[i].CopyBindPoseTo(destination, ref boneIndex);
-			}
-		}
+            for (int i = 0; i < children.Count; i++)
+            {
+                children[i].CopyBindPoseTo(destination, ref boneIndex);
+            }
+        }
 
         internal static SkinnedModelBone Read(ContentReader input)
         {

--- a/XNAnimation/SkinnedModelBone.cs
+++ b/XNAnimation/SkinnedModelBone.cs
@@ -105,9 +105,11 @@ namespace XNAnimation
         private void CopyBindPoseTo(Pose[] destination, ref int boneIndex)
         {
             destination[boneIndex++] = bindPose;
-            foreach (SkinnedModelBone bone in children)
-                bone.CopyBindPoseTo(destination, ref boneIndex);
-        }
+			for (int i = 0; i < children.Count; i++)
+			{
+				children[i].CopyBindPoseTo(destination, ref boneIndex);
+			}
+		}
 
         internal static SkinnedModelBone Read(ContentReader input)
         {

--- a/XNAnimation/SkinnedModelBone.cs
+++ b/XNAnimation/SkinnedModelBone.cs
@@ -105,11 +105,11 @@ namespace XNAnimation
         private void CopyBindPoseTo(Pose[] destination, ref int boneIndex)
         {
             destination[boneIndex++] = bindPose;
-			for (int i = 0; i < children.Count; i++)
-			{
-				children[i].CopyBindPoseTo(destination, ref boneIndex);
-			}
-		}
+            for (int i = 0; i < children.Count; i++)
+            {
+                children[i].CopyBindPoseTo(destination, ref boneIndex);
+            }
+        }
 
         internal static SkinnedModelBone Read(ContentReader input)
         {
@@ -129,7 +129,6 @@ namespace XNAnimation
 
             // Read bone parent
             input.ReadSharedResource<SkinnedModelBone>(
-                delegate(SkinnedModelBone parentBone) { skinnedBone.parent = parentBone; });
 
             // Read bone children
             int numChildren = input.ReadInt32();
@@ -137,7 +136,6 @@ namespace XNAnimation
             for (int i = 0; i < numChildren; i++)
             {
                 input.ReadSharedResource<SkinnedModelBone>(
-                    delegate(SkinnedModelBone childBone) { childrenList.Add(childBone); });
             }
             skinnedBone.children = new SkinnedModelBoneCollection(childrenList);
 


### PR DESCRIPTION
AnimationController.cs -> Update -> UpdateAnimationTime -> skeleton[0].CopyBindPoseTo(localBonePoses) allocates heap memory. If you set an animation with many bones or very high playback speed the effect is most notable.

![image](https://github.com/user-attachments/assets/af8ff6b1-2c9f-4f08-bacc-e8fe7747fe9b)

This happens when you iterate over the children SkinnedModelBone collection, I'm not 100% sure why this would allocate enumerators, I suspect it has something to do with the collection type.

Proposed solution is to simply not use a foreach loop but a simple for loop instead which does not require any such enumerators regardless of the collection type.

The only change here is the replacement of foreach with for as mentioned.
![image](https://github.com/user-attachments/assets/a43165d0-2a75-4919-9cbe-9973d2ab4cc1)
